### PR TITLE
RNShimmer: set deployment target to iOS 8.

### DIFF
--- a/ios/RNShimmer.xcodeproj/project.pbxproj
+++ b/ios/RNShimmer.xcodeproj/project.pbxproj
@@ -261,6 +261,7 @@
 					"$(SRCROOT)/../../react-native/React/**",
 					"$(SRCROOT)/../../node_modules/react-native/React/**",
 				);
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -276,6 +277,7 @@
 					"$(SRCROOT)/../../react-native/React/**",
 					"$(SRCROOT)/../../node_modules/react-native/React/**",
 				);
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
Shimmer supports iOS 6 and react-native supports iOS 8, so it makes sense to support at least iOS 8 (instead of the default iOS 9.2).
Leaving the default results in a few warnings when linking with an executable that supports 9.0 for example.