### PR TITLE
Handle RN 0.47 breaking change on Android

### DIFF
--- a/android/src/main/java/com/oblador/shimmer/RNShimmerPackage.java
+++ b/android/src/main/java/com/oblador/shimmer/RNShimmerPackage.java
@@ -21,7 +21,7 @@ public class RNShimmerPackage implements ReactPackage {
         return new ArrayList<>();
     }
 
-    @Override
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
RN 0.47 removed createJSModules from ReactPackage [commit](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8)