### PR TITLE
Import PropTypes from 'prop-types' package

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
+import PropTypes from 'prop-types';
 import React, {
   Component,
-  PropTypes,
 } from 'react';
 
 import {

--- a/package.json
+++ b/package.json
@@ -38,5 +38,8 @@
     "babel-eslint": "^6.0.4",
     "eslint": "^2.9.0",
     "eslint-plugin-react": "^5.0.1"
+  },
+  "dependencies": {
+    "prop-types": "^15.6.0"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/oblador/react-native-shimmer/issues/11