### PR TITLE
Fix Xcode 12 compatibility

### DIFF
--- a/react-native-shimmer.podspec
+++ b/react-native-shimmer.podspec
@@ -16,6 +16,6 @@ Pod::Spec.new do |s|
   s.requires_arc    = true
   s.platform        = :ios, "9.0"
 
-  s.dependency 'React', '>= 0.45.1'
+  s.dependency 'React-Core'
   s.dependency 'Shimmer', '~> 1'
 end


### PR DESCRIPTION
## Summary

Latest Xcode 12 fails to build while without a module to depend on `React-Core` directly hence this change is necessary for all native modules on iOS. This change requires React Native 0.60.2 or newer. For more details please check: [facebook/react-native#29633 (comment)](https://github.com/facebook/react-native/issues/29633#issuecomment-694187116)

## Test Plan

Use this branch to install with an app running on Xcode 12.