### PR TITLE
Remove assertion

### DIFF
--- a/ios/RNShimmeringView.m
+++ b/ios/RNShimmeringView.m
@@ -23,7 +23,6 @@
 
 - (void)removeReactSubview:(UIView *)subview
 {
-  RCTAssert(self.contentView == subview, @"Attempted to remove non-existent subview");
   self.contentView = nil;
   [subview removeFromSuperview];
 }


### PR DESCRIPTION
Hello, I am the `react-native-reanimated` maintainer. We received an issue related to your library - https://github.com/software-mansion/react-native-reanimated/issues/2554
This issue has two potential solutions:
- Add `try {} catch` by Reanimated side - https://github.com/software-mansion/react-native-reanimated/pull/2624
- Remove assertion from Shimmer side - like in this PR

An IMO better way is removing an assertion because I don't see clearly the case to use it here. Is this assertion really needed? It is possible to remove this assertion?