### PR TITLE
Update `react` peer dependency to `>=16.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "prettier": "^1.16.1"
   },
   "peerDependencies": {
-    "react": ">=16.0.0-alpha.12 <17.0.0",
+    "react": ">=16.0.0",
     "react-native": ">=0.45.1 <1.0.0"
   },
   "dependencies": {


### PR DESCRIPTION
Currently, `react` is listed as peer dependency versioned at `>=16.0.0-alpha.12 <17.0.0`.  This version is overly restrictive.  I can confirm this package works in an environment with `react >=17`. 

That particular version precludes projects from using this package in more modern react-native environments that requires `react: >=17.0.0`.

This problem becomes particularly apparent if using `npm >= 7`.     `npm7`  now errors if there are conflicting peer dependencies installed.

I am proposing simply removing the upper bound for the `react` peer dependency so users can `npm install` without error and continue to use this package in modern react-native environments!